### PR TITLE
fix: small error in scripts in docs

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -45,8 +45,8 @@ directory::
 
   cd /my/path/to/repositories/
   git clone http://bitbucket.org/jairhul/pyg4ometry
-  git checkout develop
   cd pyg4ometry
+  git checkout develop
 
   make install
 


### PR DESCRIPTION
The two lines in the docs are in the wrong order. As the right order can also be seen in the docker scripts like this one: [https://bitbucket.org/jairhul/pyg4ometry/src/develop/docker/Dockerfile-ubuntu22-pyg4ometry](https://bitbucket.org/jairhul/pyg4ometry/src/develop/docker/Dockerfile-ubuntu22-pyg4ometry)

I saw you do the development on bitbucket, but I don't have an account :(